### PR TITLE
bump: solana version to ~2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ members = [
 edition = "2021"
 
 [workspace.dependencies]
-solana-sdk = "~2.0"
-solana-client = "~2.0"
-solana-account-decoder = "~2.0"
+solana-sdk = "~2"
+solana-client = "~2"
+solana-account-decoder = "~2"


### PR DESCRIPTION
Bump Solana versions to `~2`, to avoid having to keep update versions inside the libray. This way we lock the version to a major, as the Solana libraries move relatively quickly