### PR TITLE
Rename excluded_dexes to exclude_dexes

### DIFF
--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -87,7 +87,7 @@ pub struct QuoteRequest {
     /// Platform fee in basis points
     pub platform_fee_bps: Option<u8>,
     pub dexes: Option<Dexes>,
-    pub excluded_dexes: Option<Dexes>,
+    pub exclude_dexes: Option<Dexes>,
     /// Quote only direct routes
     pub only_direct_routes: Option<bool>,
     /// Quote fit into legacy transaction
@@ -145,7 +145,7 @@ pub struct InternalQuoteRequest {
     /// Platform fee in basis points
     pub platform_fee_bps: Option<u8>,
     pub dexes: Option<Dexes>,
-    pub excluded_dexes: Option<Dexes>,
+    pub exclude_dexes: Option<Dexes>,
     /// Quote only direct routes
     pub only_direct_routes: Option<bool>,
     /// Quote fit into legacy transaction
@@ -178,7 +178,7 @@ impl From<QuoteRequest> for InternalQuoteRequest {
             minimize_slippage: request.minimize_slippage,
             platform_fee_bps: request.platform_fee_bps,
             dexes: request.dexes,
-            excluded_dexes: request.excluded_dexes,
+            exclude_dexes: request.exclude_dexes,
             only_direct_routes: request.only_direct_routes,
             as_legacy_transaction: request.as_legacy_transaction,
             restrict_intermediate_tokens: request.restrict_intermediate_tokens,


### PR DESCRIPTION
fix: rename excluded_dexes to exclude_dexes in QuoteRequest and InternalQuoteRequest structs

This was causing this field to be ignored.

https://dev.jup.ag/docs/api/swap-api/quote

Should address: https://github.com/jup-ag/jupiter-swap-api-client/issues/40