### PR TITLE
fix: Fixes prompted by lite-api.jup.ag being deprecated on 31st January 2026

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-sdk",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ const TEST_WALLET: Pubkey = pubkey!("2AQdpHJ2JpcEgPiATUXjQxA8QmafFegfQwSLWSprPic
 
 #[tokio::main]
 async fn main() {
-    let jupiter_swap_api_client = JupiterSwapApiClient::new("https://quote-api.jup.ag/v6");
+    // Create client with API key (required)
+    let jupiter_swap_api_client = JupiterSwapApiClient::new(
+        "https://quote-api.jup.ag/v6".to_string(),
+        "your-api-key".to_string()
+    );
 
     let quote_request = QuoteRequest {
         amount: 1_000_000,
@@ -81,11 +85,23 @@ You can set custom URLs via environment variables for any self-hosted Jupiter AP
 
 ```
 API_BASE_URL=https://hosted.api
+JUPITER_API_KEY=your-api-key
 ```
 
-### Paid Hosted APIs
+### API Key Requirement
 
-You can also check out some of the [paid hosted APIs](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis).
+**Note:** An API key is now required for all requests. The API key will be automatically included as the `x-api-key` header in all requests.
+
+You can obtain an API key from [paid hosted APIs](https://dev.jup.ag/portal/setup).
+
+Usage:
+
+```rust
+let jupiter_swap_api_client = JupiterSwapApiClient::new(
+    "https://quote-api.jup.ag/v6".to_string(),
+    "your-api-key".to_string()
+);
+```
 
 ## Additional Resources
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -25,7 +25,11 @@ async fn main() -> Result<()> {
     let api_base_url = env::var("API_BASE_URL").unwrap_or_else(|_| "https://quote-api.jup.ag/v6".into());
     println!("Using Jupiter base url: {}", api_base_url);
 
-    let jupiter_swap_api_client = JupiterSwapApiClient::new(api_base_url);
+    // Read API key from environment variable (required)
+    let api_key = env::var("JUPITER_API_KEY")
+        .expect("JUPITER_API_KEY environment variable must be set");
+
+    let jupiter_swap_api_client = JupiterSwapApiClient::new(api_base_url, api_key);
 
     // --- 1. GET /quote ---
     

--- a/jupiter-swap-api-client/Cargo.toml
+++ b/jupiter-swap-api-client/Cargo.toml
@@ -16,3 +16,4 @@ base64 = "0.22"
 rust_decimal = "1.36"
 solana-sdk = { workspace = true } 
 solana-account-decoder = { workspace = true }
+tracing = "0.1"

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -5,6 +5,7 @@ use reqwest::{Client, Response};
 use serde::de::DeserializeOwned;
 use swap::{SwapInstructionsResponse, SwapInstructionsResponseInternal, SwapRequest, SwapResponse};
 use thiserror::Error;
+use tracing::debug;
 
 pub mod quote;
 pub mod route_plan_with_metadata;
@@ -27,6 +28,8 @@ pub enum ClientError {
     },
     #[error("Failed to deserialize response: {0}")]
     DeserializationError(#[from] reqwest::Error),
+    #[error("Failed to parse JSON response: {0}")]
+    JsonParseError(#[from] serde_json::Error),
 }
 
 async fn check_is_success(response: Response) -> Result<Response, ClientError> {
@@ -42,10 +45,22 @@ async fn check_status_code_and_deserialize<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ClientError> {
     let response = check_is_success(response).await?;
-    response
-        .json::<T>()
-        .await
-        .map_err(ClientError::DeserializationError)
+
+    // Get the raw response text for logging
+    let response_text = response.text().await?;
+
+    // Log the raw response at debug level
+    debug!(
+        response_length = response_text.len(),
+        "Jupiter API raw response: {}", 
+        response_text
+    );
+
+    // Attempt to deserialize from the text
+    serde_json::from_str::<T>(&response_text).map_err(|e| {
+        debug!("JSON deserialization error: {}", e);
+        ClientError::JsonParseError(e)
+    })
 }
 
 impl JupiterSwapApiClient {

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -52,8 +52,7 @@ async fn check_status_code_and_deserialize<T: DeserializeOwned>(
     // Log the raw response at debug level
     debug!(
         response_length = response_text.len(),
-        "Jupiter API raw response: {}", 
-        response_text
+        "Jupiter API raw response: {}", response_text
     );
 
     // Attempt to deserialize from the text

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -15,6 +15,7 @@ pub mod transaction_config;
 #[derive(Clone)]
 pub struct JupiterSwapApiClient {
     pub base_path: String,
+    pub api_key: String,
 }
 
 #[derive(Debug, Error)]
@@ -48,8 +49,8 @@ async fn check_status_code_and_deserialize<T: DeserializeOwned>(
 }
 
 impl JupiterSwapApiClient {
-    pub fn new(base_path: String) -> Self {
-        Self { base_path }
+    pub fn new(base_path: String, api_key: String) -> Self {
+        Self { base_path, api_key }
     }
 
     pub async fn quote(&self, quote_request: &QuoteRequest) -> Result<QuoteResponse, ClientError> {
@@ -60,6 +61,7 @@ impl JupiterSwapApiClient {
             .get(url)
             .query(&internal_quote_request)
             .query(&extra_args)
+            .header("x-api-key", &self.api_key)
             .send()
             .await?;
         check_status_code_and_deserialize(response).await
@@ -74,6 +76,7 @@ impl JupiterSwapApiClient {
             .post(format!("{}/swap", self.base_path))
             .query(&extra_args)
             .json(swap_request)
+            .header("x-api-key", &self.api_key)
             .send()
             .await?;
         check_status_code_and_deserialize(response).await
@@ -86,6 +89,7 @@ impl JupiterSwapApiClient {
         let response = Client::new()
             .post(format!("{}/swap-instructions", self.base_path))
             .json(swap_request)
+            .header("x-api-key", &self.api_key)
             .send()
             .await?;
         check_status_code_and_deserialize::<SwapInstructionsResponseInternal>(response)

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -19,25 +19,38 @@ type Dexes = String;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
-/// Swap details for a single step in a multi-hop route.
+/// Swap information of each Swap occurred in the route paths
 pub struct SwapInfo {
-    /// The PublicKey of the Automated Market Maker (AMM) pool or program.
     #[serde(with = "field_as_string")]
     pub amm_key: Pubkey,
-    /// The human-readable label for the DEX/AMM (e.g., "Raydium_V4").
     pub label: String,
-    /// The input token mint for this specific swap step.
     #[serde(with = "field_as_string")]
     pub input_mint: Pubkey,
-    /// The output token mint for this specific swap step.
     #[serde(with = "field_as_string")]
     pub output_mint: Pubkey,
-    /// Estimated input amount into the AMM pool (factoring in token decimals).
+    /// An estimation of the input amount into the AMM
     #[serde(with = "field_as_string")]
     pub in_amount: u64,
-    /// Estimated output amount from the AMM pool (factoring in token decimals).
+    /// An estimation of the output amount into the AMM
     #[serde(with = "field_as_string")]
     pub out_amount: u64,
+    /// Fee amount (optional - not always returned by Jupiter)
+    #[serde(
+        with = "field_as_string",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub fee_amount: Option<u64>,
+    /// Fee token mint (optional - not always returned by Jupiter)
+    #[serde(
+        with = "field_as_string",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub fee_mint: Option<Pubkey>,
+    /// Output amount after slippage is applied
+    #[serde(with = "field_as_string")]
+    pub out_amount_after_slippage: u64,
 }
 
 // --- Swap Mode Enumeration ---
@@ -60,7 +73,10 @@ impl FromStr for SwapMode {
         match s {
             "ExactIn" => Ok(Self::ExactIn),
             "ExactOut" => Ok(Self::ExactOut),
-            _ => Err(anyhow!("'{}' is not a valid SwapMode. Expected 'ExactIn' or 'ExactOut'.", s)),
+            _ => Err(anyhow!(
+                "'{}' is not a valid SwapMode. Expected 'ExactIn' or 'ExactOut'.",
+                s
+            )),
         }
     }
 }
@@ -141,7 +157,7 @@ impl Default for QuoteRequest {
             amount: 0,
             swap_mode: None,
             // Recommended default slippage for safe operation (0.5% or 50 BPS).
-            slippage_bps: 50, 
+            slippage_bps: 50,
             auto_slippage: None,
             max_auto_slippage_bps: None,
             compute_auto_slippage: false,
@@ -164,7 +180,6 @@ impl Default for QuoteRequest {
         }
     }
 }
-
 
 #[derive(Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use crate::route_plan_with_metadata::RoutePlanWithMetadata;
-use crate::serde_helpers::{field_as_string, option_field_as_string};
+use crate::serde_helpers::field_as_string;
 use anyhow::{anyhow, Error};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -35,19 +35,13 @@ pub struct SwapInfo {
     #[serde(with = "field_as_string")]
     pub out_amount: u64,
     /// Fee amount (optional - not always returned by Jupiter)
-    #[serde(
-        with = "option_field_as_string",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
-    pub fee_amount: Option<u64>,
-    /// Fee token mint (optional - not always returned by Jupiter)
-    #[serde(
-        with = "option_field_as_string",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
-    pub fee_mint: Option<Pubkey>,
+    /// Note: When present in the API response, this comes as a string but is rarely included
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_amount: Option<String>,
+    /// Fee token mint (optional - not always returned by Jupiter)  
+    /// Note: When present in the API response, this comes as a string but is rarely included
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_mint: Option<String>,
     /// Output amount after slippage is applied
     #[serde(with = "field_as_string")]
     pub out_amount_after_slippage: u64,

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use crate::route_plan_with_metadata::RoutePlanWithMetadata;
-use crate::serde_helpers::field_as_string;
+use crate::serde_helpers::{field_as_string, option_field_as_string};
 use anyhow::{anyhow, Error};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -36,14 +36,14 @@ pub struct SwapInfo {
     pub out_amount: u64,
     /// Fee amount (optional - not always returned by Jupiter)
     #[serde(
-        with = "field_as_string",
+        with = "option_field_as_string",
         skip_serializing_if = "Option::is_none",
         default
     )]
     pub fee_amount: Option<u64>,
     /// Fee token mint (optional - not always returned by Jupiter)
     #[serde(
-        with = "field_as_string",
+        with = "option_field_as_string",
         skip_serializing_if = "Option::is_none",
         default
     )]

--- a/jupiter-swap-api-client/src/route_plan_with_metadata.rs
+++ b/jupiter-swap-api-client/src/route_plan_with_metadata.rs
@@ -29,8 +29,13 @@ pub struct SwapInfo {
     /// An estimation of the output amount into the AMM
     #[serde(with = "field_as_string")]
     pub out_amount: u64,
+    /// Fee amount (optional - not always returned by Jupiter)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_amount: Option<String>,
+    /// Fee token mint (optional - not always returned by Jupiter)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_mint: Option<String>,
+    /// Output amount after slippage is applied
     #[serde(with = "field_as_string")]
-    pub fee_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_mint: Pubkey,
+    pub out_amount_after_slippage: u64,
 }

--- a/jupiter-swap-api-client/src/serde_helpers/option_field_as_string.rs
+++ b/jupiter-swap-api-client/src/serde_helpers/option_field_as_string.rs
@@ -21,12 +21,13 @@ where
     D: Deserializer<'de>,
     <T as FromStr>::Err: std::fmt::Debug,
 {
+    // Deserialize as Option<String> to handle both null and missing fields
     let opt: Option<String> = Option::deserialize(deserializer)?;
     match opt {
-        Some(s) => s
+        Some(s) if !s.is_empty() => s
             .parse()
             .map(Some)
             .map_err(|e| de::Error::custom(format!("Parse error: {:?}", e))),
-        None => Ok(None),
+        _ => Ok(None),
     }
 }


### PR DESCRIPTION
# Branch Summary: `fix/update_to_api_response`

## Overview

This branch updates the Jupiter Swap API Client to align with recent Jupiter API changes, focusing on mandatory API key authentication, enhanced error handling, and expanded response data structures.

**Branch:** `fix/update_to_api_response`  
**Base:** `main`  
**Commits:** 6 commits ahead of main  
**Files Changed:** 8 files (+80 insertions, -25 deletions)

---

## Key Changes

### 1. **Mandatory API Key Authentication** 🔑

**Breaking Change:** API key is now required for all requests.

- Updated `JupiterSwapApiClient` constructor to require an `api_key` parameter
- API key is automatically included as `x-api-key` header in all HTTP requests
- Updated all usage examples in README and example code

**Before:**
```rust
let client = JupiterSwapApiClient::new("https://quote-api.jup.ag/v6".to_string());
```

**After:**
```rust
let client = JupiterSwapApiClient::new(
    "https://quote-api.jup.ag/v6".to_string(),
    "your-api-key".to_string()
);
```

**Files Modified:**
- `jupiter-swap-api-client/src/lib.rs` - Added `api_key` field to struct and header injection
- `example/src/main.rs` - Updated to read API key from `JUPITER_API_KEY` env variable
- `README.md` - Added API key documentation and usage examples

---

### 2. **Enhanced Error Handling & Logging** 🔍

Added comprehensive logging and improved error diagnostics for API responses.

**Changes:**
- Added `tracing` dependency for structured logging
- Introduced new `JsonParseError` variant to `ClientError` enum
- Enhanced `check_status_code_and_deserialize()` to:
  - Capture raw response text before deserialization
  - Log response length and full JSON at debug level
  - Provide detailed error context on deserialization failures

**Benefits:**
- Easier debugging of API integration issues
- Better visibility into Jupiter API responses
- Clearer error messages when response format changes

**Files Modified:**
- `jupiter-swap-api-client/Cargo.toml` - Added `tracing = "0.1"` dependency
- `jupiter-swap-api-client/src/lib.rs` - Implemented enhanced logging

---

### 3. **Updated `SwapInfo` Response Structure** 📊

Extended `SwapInfo` struct to include additional fields returned by Jupiter API v6.

**New Fields:**
- `fee_amount: Option<String>` - Optional fee amount charged by the AMM
- `fee_mint: Option<String>` - Optional fee token mint (rarely populated)
- `out_amount_after_slippage: u64` - Output amount accounting for configured slippage

**Key Notes:**
- `fee_amount` and `fee_mint` are **optional** as Jupiter API doesn't always return them
- These fields use `Option<String>` instead of deserialization helpers for flexibility
- `out_amount_after_slippage` is **required** and uses `field_as_string` serialization

**Files Modified:**
- `jupiter-swap-api-client/src/quote.rs` - Updated main `SwapInfo` struct
- `jupiter-swap-api-client/src/route_plan_with_metadata.rs` - Updated route planning `SwapInfo`
- `jupiter-swap-api-client/src/serde_helpers/option_field_as_string.rs` - Improved empty string handling

---

### 4. **Documentation & Code Quality Improvements** 📝

- **README Updates:**
  - Added "API Key Requirement" section with setup instructions
  - Updated all code examples to include API key parameter
  - Added reference to Jupiter developer portal for API key acquisition
  
- **Code Comments:**
  - Improved clarity in `SwapInfo` field descriptions
  - Added context about when optional fields are populated
  - Fixed formatting inconsistencies

- **Environment Variables:**
  - Documented `JUPITER_API_KEY` environment variable
  - Updated example code to read from environment

---

## Detailed Commit History

```
443715e - fix: Correct formatting in debug log for Jupiter API raw response in lib.rs
2f071d5 - feat: Add tracing dependency and enhance error handling with detailed logging
7cd8400 - feat: Require API key for JupiterSwapApiClient and update usage examples
25d3230 - refactor: Update fee_amount and fee_token_mint to use option_field_as_string
2e47279 - fix: Enhance SwapInfo struct with additional fields (fee details, out_amount_after_slippage)
fb95cfa - clean up
```

---

## Migration Guide

### For Existing Users

**Required Changes:**

1. **Update Constructor Calls:**
   ```rust
   // Old
   let client = JupiterSwapApiClient::new(base_url);
   
   // New
   let client = JupiterSwapApiClient::new(base_url, api_key);
   ```

2. **Obtain API Key:**
   - Visit [Jupiter Developer Portal](https://dev.jup.ag/portal/setup)
   - Generate an API key
   - Store securely in environment variables or configuration

3. **Update Environment Variables:**
   ```bash
   export JUPITER_API_KEY="your-api-key"
   ```

4. **Update Code to Handle New Fields:**
   ```rust
   // SwapInfo now includes:
   quote.swap_info.fee_amount; // Option<String>
   quote.swap_info.fee_mint; // Option<String>
   quote.swap_info.out_amount_after_slippage; // u64
   ```

**Optional Changes:**

- Enable `tracing` subscriber to capture detailed API logs
- Update error handling to account for new `JsonParseError` variant

---

## Testing Recommendations

1. **API Key Validation:**
   - Verify requests fail gracefully with invalid/missing API key
   - Confirm `x-api-key` header is present in all requests

2. **Response Parsing:**
   - Test with quotes that include fee information
   - Test with quotes where fees are absent (ensure no deserialization errors)
   - Verify `out_amount_after_slippage` calculation

3. **Error Handling:**
   - Trigger JSON parse errors to verify logging output
   - Check tracing logs contain full response bodies for debugging

4. **Backward Compatibility:**
   - Ensure existing integrations work with updated `SwapInfo` structure
   - Verify optional fields don't break existing logic

---

## Dependencies Added

| Dependency | Version | Purpose |
|------------|---------|---------|
| `tracing` | 0.1 | Structured logging for API responses and error diagnostics |

---

## Breaking Changes Summary

✅ **API Key Required** - All instantiations of `JupiterSwapApiClient` must now provide an API key  
✅ **Constructor Signature Changed** - `new()` method now takes two parameters instead of one  
⚠️ **SwapInfo Extended** - New fields added (backward compatible for deserialization)

---

## Related Resources

- [Jupiter API v6 Documentation](https://station.jup.ag/docs/v6/swap-api)
- [Jupiter Developer Portal](https://dev.jup.ag/portal/setup)
- [Self-Hosted API Guide](https://station.jup.ag/docs/apis/self-hosted)
- [Paid Hosted APIs](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis)

---

## Authors & Contributors

This branch includes contributions addressing Jupiter API v6 updates and authentication requirements.

---

## Next Steps

- [ ] Merge to `main` after testing
- [ ] Update version in `Cargo.toml` (bump minor version for breaking change)
- [ ] Publish to crates.io (if applicable)
- [ ] Notify downstream consumers of breaking changes
- [ ] Update integration tests in consuming projects

---

*Last Updated: January 23, 2026*
