### PR TITLE
feat(api): v6 → Metis v1 + Swap v2 migration with single-call /build support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_qs",
  "solana-account-decoder",
  "solana-sdk",
@@ -3158,10 +3159,11 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3175,10 +3177,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.209"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3195,6 +3206,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const TEST_WALLET: Pubkey = pubkey!("2AQdpHJ2JpcEgPiATUXjQxA8QmafFegfQwSLWSprPic
 
 #[tokio::main]
 async fn main() {
-    let jupiter_swap_api_client = JupiterSwapApiClient::new("https://quote-api.jup.ag/v6");
+    let jupiter_swap_api_client = JupiterSwapApiClient::new("https://api.jup.ag/swap/v1");
 
     let quote_request = QuoteRequest {
         amount: 1_000_000,

--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ You can also check out some of the [paid hosted APIs](https://station.jup.ag/doc
 
 ## Additional Resources
 
-- [Jupiter Swap API Documentation](https://station.jup.ag/docs/v6/swap-api): Learn more about the Jupiter Swap API and its capabilities.
+- [Jupiter Swap API Documentation](https://developers.jup.ag/docs/swap): Learn more about the Jupiter Swap API and its capabilities.
 - [jup.ag Website](https://jup.ag/): Explore the official website for additional information and resources.

--- a/jupiter-swap-api-client/Cargo.toml
+++ b/jupiter-swap-api-client/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_qs = "0.13"
+serde_path_to_error = "0.1.20"
 reqwest = { version = "0.12", features = ["json"] }
 base64 = "0.22"
 rust_decimal = "1.36"

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -3,9 +3,9 @@
 
 use std::fmt;
 
-use crate::serde_helpers::{option_field_as_string, field_as_string};
+use crate::{route_plan_with_metadata::RoutePlanWithMetadata, serde_helpers::{field_as_string, option_field_as_string}};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{instruction::{AccountMeta, Instruction}, pubkey::Pubkey};
 
 /// Comma-delimited list of Decentralized Exchange (DEX) labels (e.g., "Raydium,Orca").
 type Dexes = String;
@@ -166,6 +166,165 @@ impl From<BuildRequest> for InternalBuildRequest {
             destination_token_account: request.destination_token_account,
             native_destination_account: request.native_destination_account,
             blockhash_slots_to_expiry: request.blockhash_slots_to_expiry,
+        }
+    }
+}
+
+pub mod base64_serialize_deserialize {
+  use base64::{engine::general_purpose::STANDARD, Engine};
+  use serde::{de, Deserializer, Serializer};
+
+  use super::*;
+  pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+      let base58 = STANDARD.encode(v);
+      String::serialize(&base58, s)
+  }
+
+  pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+  where
+      D: Deserializer<'de>,
+  {
+      let field_string = String::deserialize(deserializer)?;
+      STANDARD
+          .decode(field_string)
+          .map_err(|e| de::Error::custom(format!("base64 decoding error: {:?}", e)))
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct BuildInstructionsResponse {
+    /// The mint of the token being swapped (given).
+    pub input_mint: Pubkey,
+    /// The mint of the token to be received (wanted).
+    pub output_mint: Pubkey,
+    pub in_amount: u64,
+    pub out_amount: u64,
+    /// Minimum output amount after slippage
+    pub other_amount_threshold: u64,
+    pub swap_mode: String,
+    pub slippage_bps: u16,
+    pub route_plan: RoutePlanWithMetadata,
+    /// Compute unit price instruction (does not include compute unit limit)
+    pub compute_budget_instructions: Vec<Instruction>,
+    /// Pre-swap setup instructions (e.g. create ATAs)
+    pub setup_instructions: Vec<Instruction>,
+    pub swap_instruction: Instruction,
+    /// Post-swap cleanup instruction
+    pub cleanup_instruction: Instruction,
+    pub other_instructions: Vec<Instruction>,
+    pub tip_instruction: Instruction,
+    pub addresses_by_lookup_table_address: Vec<Pubkey>
+}
+
+impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
+  fn from(value: BuildInstructionsResponseInternal) -> Self {
+      Self {
+          compute_budget_instructions: value
+              .compute_budget_instructions
+              .into_iter()
+              .map(Into::into)
+              .collect(),
+          setup_instructions: value
+              .setup_instructions
+              .into_iter()
+              .map(Into::into)
+              .collect(),
+          swap_instruction: value.swap_instruction.into(),
+          cleanup_instruction: value.cleanup_instruction.into(),
+          other_instructions: value
+              .other_instructions
+              .into_iter()
+              .map(Into::into)
+              .collect(),
+          addresses_by_lookup_table_address: value
+              .addresses_by_lookup_table_address
+              .into_iter()
+              .map(|p| p.0)
+              .collect(),
+        tip_instruction: value.tip_instruction.into(),
+        input_mint: value.input_mint,
+        output_mint: value.output_mint,
+        in_amount: value.in_amount,
+        out_amount: value.out_amount,
+        other_amount_threshold: value.other_amount_threshold,
+        swap_mode: value.swap_mode,
+        slippage_bps: value.slippage_bps,
+        route_plan: value.route_plan,
+      }
+  }
+}
+
+// Duplicate for deserialization
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildInstructionsResponseInternal {
+    /// The mint of the token being swapped (given).
+    #[serde(with = "field_as_string")]
+    pub input_mint: Pubkey,
+    /// The mint of the token to be received (wanted).
+    #[serde(with = "field_as_string")]
+    pub output_mint: Pubkey,
+    #[serde(with = "field_as_string")]
+    pub in_amount: u64,
+    #[serde(with = "field_as_string")]
+    pub out_amount: u64,
+    /// Minimum output amount after slippage
+    #[serde(with = "field_as_string")]
+    pub other_amount_threshold: u64,
+    pub swap_mode: String,
+    pub slippage_bps: u16,
+    pub route_plan: RoutePlanWithMetadata,
+    /// Compute unit price instruction (does not include compute unit limit)
+    pub compute_budget_instructions: Vec<InstructionInternal>,
+    /// Pre-swap setup instructions (e.g. create ATAs)
+    pub setup_instructions: Vec<InstructionInternal>,
+    pub swap_instruction: InstructionInternal,
+    /// Post-swap cleanup instruction
+    pub cleanup_instruction: InstructionInternal,
+    pub other_instructions: Vec<InstructionInternal>,
+    pub tip_instruction: InstructionInternal,
+    pub addresses_by_lookup_table_address: Vec<PubkeyInternal>
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PubkeyInternal(#[serde(with = "field_as_string")] Pubkey);
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionInternal {
+    #[serde(with = "field_as_string")]
+    pub program_id: Pubkey,
+    pub accounts: Vec<AccountMetaInternal>,
+    #[serde(with = "base64_serialize_deserialize")]
+    pub data: Vec<u8>,
+}
+
+impl From<InstructionInternal> for Instruction {
+  fn from(val: InstructionInternal) -> Self {
+      Instruction {
+          program_id: val.program_id,
+          accounts: val.accounts.into_iter().map(Into::into).collect(),
+          data: val.data,
+      }
+  }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountMetaInternal {
+    #[serde(with = "field_as_string")]
+    pub pubkey: Pubkey,
+    pub is_signer: bool,
+    pub is_writable: bool,
+}
+
+impl From<AccountMetaInternal> for AccountMeta {
+    fn from(val: AccountMetaInternal) -> Self {
+        AccountMeta {
+            pubkey: val.pubkey,
+            is_signer: val.is_signer,
+            is_writable: val.is_writable,
         }
     }
 }

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use crate::{route_plan_with_metadata::RoutePlanWithMetadata, serde_helpers::{field_as_string, option_field_as_string}};
+use crate::{serde_helpers::{field_as_string, option_field_as_string}};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use solana_sdk::{instruction::{AccountMeta, Instruction}, pubkey::Pubkey};
 
@@ -11,6 +11,39 @@ use solana_sdk::{instruction::{AccountMeta, Instruction}, pubkey::Pubkey};
 type Dexes = String;
 
 // --- Main Request Structures ---
+
+pub type RoutePlanWithMetadata = Vec<RoutePlanStep>;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutePlanStep {
+    pub swap_info: SwapInfo,
+    pub percent: f64,
+    pub bps: u16,
+    pub usd_value: f64
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapInfo {
+    #[serde(with = "field_as_string")]
+    pub amm_key: Pubkey,
+    pub label: String,
+    #[serde(with = "field_as_string")]
+    pub input_mint: Pubkey,
+    #[serde(with = "field_as_string")]
+    pub output_mint: Pubkey,
+    /// An estimation of the input amount into the AMM
+    #[serde(with = "field_as_string")]
+    pub in_amount: u64,
+    /// An estimation of the output amount into the AMM
+    #[serde(with = "field_as_string")]
+    pub out_amount: u64,
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_amount: Option<u64>,
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_mint: Option<Pubkey>,
+}
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -1,7 +1,7 @@
 //! Build data structures for requesting a swap price and handling the response.
 //! This is typically used by a DeFi routing or aggregation service on Solana.
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use crate::{serde_helpers::{field_as_string, option_field_as_string}};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -246,7 +246,7 @@ pub struct BuildInstructionsResponse {
     pub cleanup_instruction: Option<Instruction>,
     pub other_instructions: Vec<Instruction>,
     pub tip_instruction: Option<Instruction>,
-    pub addresses_by_lookup_table_address: Option<Vec<Pubkey>>
+    pub addresses_by_lookup_table_address: Option<HashMap<Pubkey, Vec<Pubkey>>>
 }
 
 impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
@@ -271,7 +271,11 @@ impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
               .collect(),
           addresses_by_lookup_table_address: value
               .addresses_by_lookup_table_address
-              .map(|v| v.into_iter().map(|p| p.0).collect()),
+              .map(|map| {
+                  map.into_iter()
+                      .map(|(k, v)| (k.0, v.into_iter().map(|p| p.0).collect()))
+                      .collect()
+              }),
         tip_instruction: value.tip_instruction.map(|i| i.into()),
         input_mint: value.input_mint,
         output_mint: value.output_mint,
@@ -314,10 +318,10 @@ pub struct BuildInstructionsResponseInternal {
     pub cleanup_instruction: Option<InstructionInternal>,
     pub other_instructions: Vec<InstructionInternal>,
     pub tip_instruction: Option<InstructionInternal>,
-    pub addresses_by_lookup_table_address: Option<Vec<PubkeyInternal>>
+    pub addresses_by_lookup_table_address: Option<HashMap<PubkeyInternal, Vec<PubkeyInternal>>>
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct PubkeyInternal(#[serde(with = "field_as_string")] Pubkey);
 

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -20,7 +20,7 @@ pub struct RoutePlanStep {
     pub swap_info: SwapInfo,
     pub percent: f64,
     pub bps: u16,
-    pub usd_value: f64
+    pub usd_value: Option<f64>
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -210,10 +210,10 @@ pub struct BuildInstructionsResponse {
     pub setup_instructions: Vec<Instruction>,
     pub swap_instruction: Instruction,
     /// Post-swap cleanup instruction
-    pub cleanup_instruction: Instruction,
+    pub cleanup_instruction: Option<Instruction>,
     pub other_instructions: Vec<Instruction>,
-    pub tip_instruction: Instruction,
-    pub addresses_by_lookup_table_address: Vec<Pubkey>
+    pub tip_instruction: Option<Instruction>,
+    pub addresses_by_lookup_table_address: Option<Vec<Pubkey>>
 }
 
 impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
@@ -230,7 +230,7 @@ impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
               .map(Into::into)
               .collect(),
           swap_instruction: value.swap_instruction.into(),
-          cleanup_instruction: value.cleanup_instruction.into(),
+          cleanup_instruction: value.cleanup_instruction.map(|i| i.into()),
           other_instructions: value
               .other_instructions
               .into_iter()
@@ -238,10 +238,8 @@ impl From<BuildInstructionsResponseInternal> for BuildInstructionsResponse {
               .collect(),
           addresses_by_lookup_table_address: value
               .addresses_by_lookup_table_address
-              .into_iter()
-              .map(|p| p.0)
-              .collect(),
-        tip_instruction: value.tip_instruction.into(),
+              .map(|v| v.into_iter().map(|p| p.0).collect()),
+        tip_instruction: value.tip_instruction.map(|i| i.into()),
         input_mint: value.input_mint,
         output_mint: value.output_mint,
         in_amount: value.in_amount,
@@ -280,10 +278,10 @@ pub struct BuildInstructionsResponseInternal {
     pub setup_instructions: Vec<InstructionInternal>,
     pub swap_instruction: InstructionInternal,
     /// Post-swap cleanup instruction
-    pub cleanup_instruction: InstructionInternal,
+    pub cleanup_instruction: Option<InstructionInternal>,
     pub other_instructions: Vec<InstructionInternal>,
-    pub tip_instruction: InstructionInternal,
-    pub addresses_by_lookup_table_address: Vec<PubkeyInternal>
+    pub tip_instruction: Option<InstructionInternal>,
+    pub addresses_by_lookup_table_address: Option<Vec<PubkeyInternal>>
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/jupiter-swap-api-client/src/build.rs
+++ b/jupiter-swap-api-client/src/build.rs
@@ -1,0 +1,321 @@
+//! Build data structures for requesting a swap price and handling the response.
+//! This is typically used by a DeFi routing or aggregation service on Solana.
+
+use std::fmt;
+
+use crate::serde_helpers::{option_field_as_string, field_as_string};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use solana_sdk::pubkey::Pubkey;
+
+/// Comma-delimited list of Decentralized Exchange (DEX) labels (e.g., "Raydium,Orca").
+type Dexes = String;
+
+// --- Main Request Structures ---
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+/// Full request payload sent by the client to obtain a swap quote and route plan.
+pub struct BuildRequest {
+    /// The mint of the token being swapped (given).
+    #[serde(with = "field_as_string")]
+    pub input_mint: Pubkey,
+    /// The mint of the token to be received (wanted).
+    #[serde(with = "field_as_string")]
+    pub output_mint: Pubkey,
+    /// The amount of the input or output token (depending on `swap_mode`), factoring in token decimals.
+    #[serde(with = "field_as_string")]
+    pub amount: u64,
+    /// Your wallet address    
+    #[serde(with = "field_as_string")]
+    pub taker: Pubkey,
+    /// SOL tip amount in lamports. Adds a tip instruction for use with /submit
+    #[serde(with = "option_field_as_string")]
+    pub tip_amount: Option<u64>,
+    /// Priority fee percentile for the CU price instruction. Named levels: "medium" (25th), "high" (50th), "veryHigh" (75th), or an integer 0-10000 in bps.
+    pub compute_unit_price_percentile: Option<ComputeUnitPricePercentile>,
+    /// “fast” for reduced latency routing (BETA)
+    pub mode: Option<QuoteMode>,
+    /// Maximum accounts for the swap route (1-64). Default: 64.
+    pub max_accounts: Option<u8>,
+    /// Integrator platform fee in bps (requires feeAccount)
+    pub platform_fee_bps: Option<u16>,
+    /// Token account to collect platform fees
+    #[serde(with = "option_field_as_string")]
+    pub fee_account: Option<Pubkey>,
+    /// Account that pays transaction fees and rent. Defaults to taker when not passed in.
+    #[serde(with = "option_field_as_string")]
+    pub payer: Option<Pubkey>,
+    /// Whether to wrap/unwrap SOL. Defaults to true.
+    pub wrap_and_unwrap_sol: Option<bool>,
+    /// Comma-separated list of DEXes to restrict routing to. Mutually exclusive with excludeDexes.
+    pub dexes: Option<Dexes>,
+    /// Comma-separated list of DEXes to exclude. Mutually exclusive with dexes.
+    pub exclude_dexes: Option<Dexes>,
+    /// SPL token account to receive output tokens. Mutually exclusive with nativeDestinationAccount.
+    #[serde(with = "option_field_as_string")]
+    pub destination_token_account: Option<Pubkey>,
+    /// Native SOL account to receive output. Mutually exclusive with destinationTokenAccount.
+    #[serde(with = "option_field_as_string")]
+    pub native_destination_account: Option<Pubkey>,
+    /// Number of slots until the blockhash expires. Defaults to 150.
+    pub blockhash_slots_to_expiry: Option<u16>,
+    /// Slippage tolerance in basis points. Defaults to 50.
+    pub slippage_bps: Option<SlippageBps>
+}
+
+// Implement Default manually to provide a safer default slippage_bps.
+impl Default for BuildRequest {
+    fn default() -> Self {
+        BuildRequest {
+            // Standard default fields
+            input_mint: Pubkey::default(),
+            output_mint: Pubkey::default(),
+            amount: 0,
+            taker: Pubkey::default(),
+            tip_amount: None,
+            compute_unit_price_percentile: None,
+            mode: None,
+            max_accounts: None,
+            platform_fee_bps: None,
+            fee_account: None,
+            payer: None,
+            wrap_and_unwrap_sol: None,
+            dexes: None,
+            exclude_dexes: None,
+            destination_token_account: None,
+            native_destination_account: None,
+            blockhash_slots_to_expiry: None,
+            slippage_bps: None,
+        }
+    }
+}
+
+
+#[derive(Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+/// Internal structure used by the routing engine, excluding fields unnecessary for the core logic.
+/// This structure is derived from `BuildRequest` but omits external/extra configuration fields.
+pub struct InternalBuildRequest {
+    /// The mint of the token being swapped (given).
+    #[serde(with = "field_as_string")]
+    pub input_mint: Pubkey,
+    /// The mint of the token to be received (wanted).
+    #[serde(with = "field_as_string")]
+    pub output_mint: Pubkey,
+    /// The amount of the input or output token (depending on `swap_mode`), factoring in token decimals.
+    #[serde(with = "field_as_string")]
+    pub amount: u64,
+    /// Your wallet address    
+    #[serde(with = "field_as_string")]
+    pub taker: Pubkey,
+    /// SOL tip amount in lamports. Adds a tip instruction for use with /submit
+    #[serde(with = "option_field_as_string")]
+    pub tip_amount: Option<u64>,
+    /// Priority fee percentile for the CU price instruction. Named levels: "medium" (25th), "high" (50th), "veryHigh" (75th), or an integer 0-10000 in bps.
+    pub compute_unit_price_percentile: Option<ComputeUnitPricePercentile>,
+    /// “fast” for reduced latency routing (BETA)
+    pub mode: Option<QuoteMode>,
+    /// Maximum accounts for the swap route (1-64). Default: 64.
+    pub max_accounts: Option<u8>,
+    /// Integrator platform fee in bps (requires feeAccount)
+    pub platform_fee_bps: Option<u16>,
+    /// Token account to collect platform fees
+    #[serde(with = "option_field_as_string")]
+    pub fee_account: Option<Pubkey>,
+    /// Account that pays transaction fees and rent. Defaults to taker when not passed in.
+    #[serde(with = "option_field_as_string")]
+    pub payer: Option<Pubkey>,
+    /// Whether to wrap/unwrap SOL. Defaults to true.
+    pub wrap_and_unwrap_sol: Option<bool>,
+    /// Comma-separated list of DEXes to restrict routing to. Mutually exclusive with excludeDexes.
+    pub dexes: Option<Dexes>,
+    /// Comma-separated list of DEXes to exclude. Mutually exclusive with dexes.
+    pub exclude_dexes: Option<Dexes>,
+    /// SPL token account to receive output tokens. Mutually exclusive with nativeDestinationAccount.
+    #[serde(with = "option_field_as_string")]
+    pub destination_token_account: Option<Pubkey>,
+    /// Native SOL account to receive output. Mutually exclusive with destinationTokenAccount.
+    #[serde(with = "option_field_as_string")]
+    pub native_destination_account: Option<Pubkey>,
+    /// Number of slots until the blockhash expires. Defaults to 150.
+    pub blockhash_slots_to_expiry: Option<u16>,
+    /// Slippage tolerance in basis points. Defaults to 50.
+    pub slippage_bps: Option<SlippageBps>
+}
+
+impl From<BuildRequest> for InternalBuildRequest {
+    /// Converts a client's QuoteRequest into the simplified InternalQuoteRequest used for core routing.
+    fn from(request: BuildRequest) -> Self {
+        InternalBuildRequest {
+            // Fields are explicitly mapped, dropping request.quote_args and other specific fields.
+            input_mint: request.input_mint,
+            output_mint: request.output_mint,
+            amount: request.amount,
+            slippage_bps: request.slippage_bps,
+            platform_fee_bps: request.platform_fee_bps,
+            dexes: request.dexes,
+            max_accounts: request.max_accounts,
+            taker: request.taker,
+            tip_amount: request.tip_amount,
+            compute_unit_price_percentile: request.compute_unit_price_percentile,
+            mode: request.mode,
+            fee_account: request.fee_account,
+            payer: request.payer,
+            wrap_and_unwrap_sol: request.wrap_and_unwrap_sol,
+            exclude_dexes: request.exclude_dexes,
+            destination_token_account: request.destination_token_account,
+            native_destination_account: request.native_destination_account,
+            blockhash_slots_to_expiry: request.blockhash_slots_to_expiry,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ComputeUnitPricePercentile {
+    /// 25th percentile.
+    Medium,
+    /// 50th percentile.
+    High,
+    /// 75th percentile.
+    VeryHigh,
+    /// Arbitrary percentile in basis points (0–10 000).
+    Bps(u16),
+}
+
+impl ComputeUnitPricePercentile {
+    pub fn from_bps(bps: u16) -> Result<Self, &'static str> {
+        if bps > 10_000 {
+            Err("computeUnitPricePercentile bps must be 0–10 000")
+        } else {
+            Ok(Self::Bps(bps))
+        }
+    }
+}
+
+impl Serialize for ComputeUnitPricePercentile {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Medium   => s.serialize_str("medium"),
+            Self::High     => s.serialize_str("high"),
+            Self::VeryHigh => s.serialize_str("veryHigh"),
+            Self::Bps(n)   => s.serialize_u16(*n),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ComputeUnitPricePercentile {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ComputeUnitPricePercentile;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(r#""medium", "high", "veryHigh", or an integer 0–10 000"#)
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "medium"   => Ok(ComputeUnitPricePercentile::Medium),
+                    "high"     => Ok(ComputeUnitPricePercentile::High),
+                    "veryHigh" => Ok(ComputeUnitPricePercentile::VeryHigh),
+                    other      => Err(E::unknown_variant(other, &["medium", "high", "veryHigh"])),
+                }
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                let bps = u16::try_from(v)
+                    .map_err(|_| E::custom(format!("{v} exceeds maximum bps of 10 000")))?;
+                ComputeUnitPricePercentile::from_bps(bps)
+                    .map_err(E::custom)
+            }
+
+            // JSON integers can arrive as i64 too
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                if v < 0 {
+                    return Err(E::custom(format!("{v} is negative")));
+                }
+                self.visit_u64(v as u64)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum QuoteMode {
+    /// Reduced latency routing at the cost of route optimality. Currently in BETA.
+    #[serde(rename = "fast")]
+    Fast,
+}
+
+#[derive(Debug, Clone)]
+pub enum SlippageBps {
+    /// Fixed slippage tolerance in basis points (0–10 000).
+    Bps(u16),
+    /// Real-time slippage estimation (RTSE).
+    Rtse,
+}
+
+impl Default for SlippageBps {
+    fn default() -> Self {
+        Self::Bps(50)
+    }
+}
+
+impl SlippageBps {
+    pub fn from_bps(bps: u16) -> Result<Self, &'static str> {
+        if bps > 10_000 {
+            Err("slippageBps must be 0–10 000")
+        } else {
+            Ok(Self::Bps(bps))
+        }
+    }
+}
+
+impl Serialize for SlippageBps {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Bps(n) => s.serialize_u16(*n),
+            Self::Rtse   => s.serialize_str("rtse"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SlippageBps {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = SlippageBps;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(r#"an integer 0–10 000 or "rtse""#)
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "rtse" => Ok(SlippageBps::Rtse),
+                    other  => Err(E::unknown_variant(other, &["rtse"])),
+                }
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                let bps = u16::try_from(v)
+                    .map_err(|_| E::custom(format!("{v} exceeds maximum bps of 10 000")))?;
+                SlippageBps::from_bps(bps).map_err(E::custom)
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                if v < 0 {
+                    return Err(E::custom(format!("{v} is negative")));
+                }
+                self.visit_u64(v as u64)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use swap::{SwapInstructionsResponse, SwapInstructionsResponseInternal, SwapRequest, SwapResponse};
 use thiserror::Error;
 
-use crate::build::{BuildRequest, InternalBuildRequest};
+use crate::build::{BuildInstructionsResponse, BuildInstructionsResponseInternal, BuildRequest, InternalBuildRequest};
 
 pub mod build;
 pub mod quote;
@@ -85,7 +85,7 @@ impl JupiterSwapApiClient {
     ///
     /// # Requires
     /// A V2 base URL, e.g. `https://api.jup.ag/swap/v2`
-    pub async fn build(&self, build_request: &BuildRequest) -> Result<SwapInstructionsResponse, ClientError> {
+    pub async fn build(&self, build_request: &BuildRequest) -> Result<BuildInstructionsResponse, ClientError> {
       let url = format!("{}/build", self.base_path);
       let internal_quote_request = InternalBuildRequest::from(build_request.clone());
       let response = Client::new()
@@ -93,7 +93,7 @@ impl JupiterSwapApiClient {
           .query(&internal_quote_request)
           .send()
           .await?;
-      check_status_code_and_deserialize::<SwapInstructionsResponseInternal>(response)
+      check_status_code_and_deserialize::<BuildInstructionsResponseInternal>(response)
           .await
           .map(Into::into)
     }

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -6,6 +6,9 @@ use serde::de::DeserializeOwned;
 use swap::{SwapInstructionsResponse, SwapInstructionsResponseInternal, SwapRequest, SwapResponse};
 use thiserror::Error;
 
+use crate::build::{BuildRequest, InternalBuildRequest};
+
+pub mod build;
 pub mod quote;
 pub mod route_plan_with_metadata;
 pub mod serde_helpers;
@@ -82,14 +85,12 @@ impl JupiterSwapApiClient {
     ///
     /// # Requires
     /// A V2 base URL, e.g. `https://api.jup.ag/swap/v2`
-    pub async fn build(&self, quote_request: &QuoteRequest) -> Result<SwapInstructionsResponse, ClientError> {
+    pub async fn build(&self, build_request: &BuildRequest) -> Result<SwapInstructionsResponse, ClientError> {
       let url = format!("{}/build", self.base_path);
-      let extra_args = quote_request.quote_args.clone();
-      let internal_quote_request = InternalQuoteRequest::from(quote_request.clone());
+      let internal_quote_request = InternalBuildRequest::from(build_request.clone());
       let response = Client::new()
           .get(url)
           .query(&internal_quote_request)
-          .query(&extra_args)
           .send()
           .await?;
       check_status_code_and_deserialize::<SwapInstructionsResponseInternal>(response)

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -59,6 +59,44 @@ impl JupiterSwapApiClient {
         Self { base_path }
     }
 
+    /// Fetches a quote and builds raw swap instructions in a single call using the `/build` endpoint.
+    ///
+    /// This is the V2 equivalent of calling `quote` + `swap_instructions` separately (V1/Metis required
+    /// two calls: `GET /swap/v1/quote` then `POST /swap/v1/swap-instructions`).
+    ///
+    /// Routing is handled by **Metis**, Jupiter's onchain routing engine, which finds the optimal
+    /// swap path across Solana DEXes. Unlike the assembled-transaction endpoint, this returns raw
+    /// instructions, giving you full control to:
+    /// - Add custom instructions before/after the swap
+    /// - Integrate via CPI
+    /// - Modify any part of the transaction
+    ///
+    /// Once built and signed, submit the transaction via your own RPC or use `/submit` to land it
+    /// through Jupiter's transaction infrastructure with SOL tips.
+    ///
+    /// # V2 Changes
+    /// - **Base URL**: `https://api.jup.ag/swap/v2` (previously `https://api.jup.ag/swap/v1`)
+    /// - **Single call**: `GET /swap/v2/build` (previously two calls: quote + swap-instructions)
+    /// - **`routePlan`**: fees expressed in **bps** (previously `percent` in V1)
+    /// - **Instruction format**: V2 format (incompatible with V1)
+    ///
+    /// # Requires
+    /// A V2 base URL, e.g. `https://api.jup.ag/swap/v2`
+    pub async fn build(&self, quote_request: &QuoteRequest) -> Result<SwapInstructionsResponse, ClientError> {
+      let url = format!("{}/build", self.base_path);
+      let extra_args = quote_request.quote_args.clone();
+      let internal_quote_request = InternalQuoteRequest::from(quote_request.clone());
+      let response = Client::new()
+          .get(url)
+          .query(&internal_quote_request)
+          .query(&extra_args)
+          .send()
+          .await?;
+      check_status_code_and_deserialize::<SwapInstructionsResponseInternal>(response)
+          .await
+          .map(Into::into)
+    }
+
     pub async fn quote(&self, quote_request: &QuoteRequest) -> Result<QuoteResponse, ClientError> {
         let url = format!("{}/quote", self.base_path);
         let extra_args = quote_request.quote_args.clone();

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -85,6 +85,8 @@ impl JupiterSwapApiClient {
     ///
     /// # Requires
     /// A V2 base URL, e.g. `https://api.jup.ag/swap/v2`
+    /// 
+    /// [API](https://developers.jup.ag/docs/api-reference/swap/build)
     pub async fn build(&self, build_request: &BuildRequest) -> Result<BuildInstructionsResponse, ClientError> {
       let url = format!("{}/build", self.base_path);
       let internal_quote_request = InternalBuildRequest::from(build_request.clone());

--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -24,8 +24,13 @@ pub enum ClientError {
         status: reqwest::StatusCode,
         body: String,
     },
-    #[error("Failed to deserialize response: {0}")]
-    DeserializationError(#[from] reqwest::Error),
+    #[error("Failed to read response body: {0}")]
+    BodyReadError(#[from] reqwest::Error),
+    #[error("Failed to deserialize response at path `{path}`: {source}")]
+    DeserializationError {
+        path: String,
+        source: serde_json::Error,
+    },
 }
 
 async fn check_is_success(response: Response) -> Result<Response, ClientError> {
@@ -41,10 +46,12 @@ async fn check_status_code_and_deserialize<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ClientError> {
     let response = check_is_success(response).await?;
-    response
-        .json::<T>()
-        .await
-        .map_err(ClientError::DeserializationError)
+    let text = response.text().await?;
+    let jd = &mut serde_json::Deserializer::from_str(&text);
+    serde_path_to_error::deserialize(jd).map_err(|e| ClientError::DeserializationError {
+        path: e.path().to_string(),
+        source: e.into_inner(),
+    })
 }
 
 impl JupiterSwapApiClient {

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -277,8 +277,6 @@ pub struct QuoteResponse {
     /// (e.g., minimum out for ExactIn, maximum in for ExactOut).
     #[serde(with = "field_as_string")]
     pub other_amount_threshold: u64,
-    /// The fee amount expected from the route
-    pub fee_amount: Option<u64>,
     /// The mode used for calculating the quote (ExactIn or ExactOut).
     pub swap_mode: SwapMode,
     /// The slippage basis points used for the quote calculation.

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -251,6 +251,8 @@ pub struct PlatformFee {
     /// The fee amount collected (factoring in token decimals).
     #[serde(with = "field_as_string")]
     pub amount: u64,
+    #[serde(with = "field_as_string")]
+    pub fee_amount: u64,
     /// The fee percentage collected, in basis points (BPS).
     pub fee_bps: u8,
 }

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -251,8 +251,6 @@ pub struct PlatformFee {
     /// The fee amount collected (factoring in token decimals).
     #[serde(with = "field_as_string")]
     pub amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_amount: u64,
     /// The fee percentage collected, in basis points (BPS).
     pub fee_bps: u8,
 }

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -278,7 +278,7 @@ pub struct QuoteResponse {
     #[serde(with = "field_as_string")]
     pub other_amount_threshold: u64,
     /// The fee amount expected from the route
-    pub fee_amount: u64,
+    pub fee_amount: Option<u64>,
     /// The mode used for calculating the quote (ExactIn or ExactOut).
     pub swap_mode: SwapMode,
     /// The slippage basis points used for the quote calculation.

--- a/jupiter-swap-api-client/src/quote.rs
+++ b/jupiter-swap-api-client/src/quote.rs
@@ -277,6 +277,8 @@ pub struct QuoteResponse {
     /// (e.g., minimum out for ExactIn, maximum in for ExactOut).
     #[serde(with = "field_as_string")]
     pub other_amount_threshold: u64,
+    /// The fee amount expected from the route
+    pub fee_amount: u64,
     /// The mode used for calculating the quote (ExactIn or ExactOut).
     pub swap_mode: SwapMode,
     /// The slippage basis points used for the quote calculation.

--- a/jupiter-swap-api-client/src/route_plan_with_metadata.rs
+++ b/jupiter-swap-api-client/src/route_plan_with_metadata.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 
-use crate::serde_helpers::field_as_string;
+use crate::serde_helpers::{field_as_string, option_field_as_string};
 
 /// Topologically sorted DAG with additional metadata for rendering
 pub type RoutePlanWithMetadata = Vec<RoutePlanStep>;
@@ -29,8 +29,8 @@ pub struct SwapInfo {
     /// An estimation of the output amount into the AMM
     #[serde(with = "field_as_string")]
     pub out_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_mint: Pubkey,
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_amount: Option<u64>,
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_mint: Option<Pubkey>,
 }


### PR DESCRIPTION
## Deprecation fixes & V1/V2 API support

Addresses the deprecation of `quote-api.jup.ag/v6` and adds first-class support for both the V1 Metis and V2 Swap APIs.

### Changes

**README**
- Removed dead `quote-api.jup.ag/v6` and old documentation links
- Updated base URLs and code examples to reflect current endpoints

**V1 Metis compatibility (`https://api.jup.ag/swap/v1`)**
- `SwapInfo` was not back-compatible with V1 responses — `fee_amount` and `fee_mint` are not guaranteed fields in V1, so both are now `Option<_>` to handle partial responses gracefully

**V2 Swap support (`https://api.jup.ag/swap/v2`)**
- Added `build()` — a typed binding for the `/build` endpoint that collapses the previous two-call flow (`/quote` + `/swap_instructions`) into a single request, matching the V2 API design
- Includes full request/response structs with documentation and inline references to aid future maintenance
- Should meaningfully reduce quote latency for consumers who migrate to V2

### Motivation

The V6 endpoint is deprecated and its not working. This brings the SDK in line with Jupiter's current API surface so projects depending on this crate aren't blocked.